### PR TITLE
Remove obsolete fails_with statement

### DIFF
--- a/prosody.rb
+++ b/prosody.rb
@@ -15,10 +15,6 @@ class Prosody < Formula
   depends_on "libidn"
   depends_on "openssl"
 
-  fails_with :llvm do
-    cause "Lua itself compiles with llvm, but may fail when other software tries to link."
-  end
-
   resource "luarocks" do
     url "http://luarocks.github.io/luarocks/releases/luarocks-2.4.1.tar.gz"
     sha256 "e429e0af9764bfd5cb640cac40f9d4ed1023fa17c052dff82ed0a41c05f3dcf9"


### PR DESCRIPTION
Fixes this error:

> Error: Calling fails_with :llvm is deprecated!
> There is no replacement.